### PR TITLE
install curl package because node-install requires curl command

### DIFF
--- a/gcp/image/ansible/00_devel.yml
+++ b/gcp/image/ansible/00_devel.yml
@@ -33,6 +33,8 @@
     - apt: name=libxslt1-dev state=present
     - apt: name=readline-common state=present
     - apt: name=re2c state=present
+    # for node-install
+    - apt: name=curl state=present
     # for php --with-openssl
     - apt: name=pkg-config
     # make Ubuntu 15.04 image root fs to rw 


### PR DESCRIPTION
Install curl package expressly because Ubuntu minimal install has no curl command.
