### PR TITLE
fix isucon5-qualify git repository url

### DIFF
--- a/gcp/bench/ansible/06_deploy_bench_tool.yml
+++ b/gcp/bench/ansible/06_deploy_bench_tool.yml
@@ -4,13 +4,9 @@
   sudo: yes
   sudo_user: isucon
   tasks:
-    - file: path=/home/isucon/.ssh state=directory owner=isucon mode=755
-    - copy: src=../keys/root_id_rsa dest=/home/isucon/.ssh/deploy_id_rsa owner=isucon mode=600
     - git:
-        repo=git@github.com:tagomoris/isucon5-qualify.git
+        repo=https://github.com/isucon/isucon5-qualify.git
         dest=/home/isucon/isucon5-qualify
-        key_file=/home/isucon/.ssh/deploy_id_rsa
-        accept_hostkey=yes
     - name: ruby
       shell: PATH=/home/isucon/.local/ruby/bin:$PATH bundle install
       args:

--- a/gcp/eventapp/ansible/07_deploy_event_app.yml
+++ b/gcp/eventapp/ansible/07_deploy_event_app.yml
@@ -4,13 +4,9 @@
   sudo: yes
   sudo_user: isucon
   tasks:
-    - file: path=/home/isucon/.ssh state=directory owner=isucon mode=755
-    - copy: src=../keys/root_id_rsa dest=/home/isucon/.ssh/deploy_id_rsa owner=isucon mode=600
     - git:
-        repo=git@github.com:tagomoris/isucon5-qualify.git
+        repo=https://github.com/isucon/isucon5-qualify.git
         dest=/home/isucon/isucon5-qualify
-        key_file=/home/isucon/.ssh/deploy_id_rsa
-        accept_hostkey=yes
     - name: ruby
       shell: PATH=/home/isucon/.local/ruby/bin:$PATH bundle install
       args:

--- a/gcp/image/ansible/04_deploy_application.yml
+++ b/gcp/image/ansible/04_deploy_application.yml
@@ -4,13 +4,9 @@
   sudo: yes
   sudo_user: isucon
   tasks:
-    - file: path=/home/isucon/.ssh state=directory owner=isucon mode=755
-    - copy: src=../keys/root_id_rsa dest=/home/isucon/.ssh/deploy_id_rsa owner=isucon mode=600
     - git:
-        repo=git@github.com:tagomoris/isucon5-qualify.git
+        repo=https://github.com/isucon/isucon5-qualify.git
         dest=/tmp/isucon5-qualify
-        key_file=/home/isucon/.ssh/deploy_id_rsa
-        accept_hostkey=yes
     - command: rsync -avz --delete /tmp/isucon5-qualify/webapp /home/isucon/
     # /home/isucon/webapp/{etc,go,java,nodejs,perl,php,python,ruby,scala,sql,static}
     - command: rm -rf /tmp/isucon5-qualify


### PR DESCRIPTION
We can use isucon/isucon5-qualify instead of tagomoris/isucon5-qualify. Use https scheme to remove unwanted ssh key.
