### PR TITLE
fix kill command path

### DIFF
--- a/gcp/bench/files/systemd.ruby.service
+++ b/gcp/bench/files/systemd.ruby.service
@@ -8,7 +8,7 @@ EnvironmentFile=/home/isucon/env.bench.sh
 User=isucon
 
 ExecStart=/home/isucon/.local/ruby/bin/bundle exec ruby ./agent.rb
-ExecStop=/usr/bin/kill -QUIT $MAINPID
+ExecStop=/bin/kill -QUIT $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/gcp/eventapp/files/systemd.ruby.service
+++ b/gcp/eventapp/files/systemd.ruby.service
@@ -8,7 +8,7 @@ EnvironmentFile=/home/isucon/env.bench.sh
 User=isucon
 
 ExecStart=/home/isucon/.local/ruby/bin/bundle exec foreman start
-ExecStop=/usr/bin/kill -QUIT $MAINPID
+ExecStop=/bin/kill -QUIT $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/gcp/image/files/systemd.ruby.service
+++ b/gcp/image/files/systemd.ruby.service
@@ -9,7 +9,7 @@ Environment=RACK_ENV=production
 PIDFile=/home/isucon/webapp/ruby/unicorn.pid
 
 ExecStart=/home/isucon/.local/ruby/bin/bundle exec unicorn -c unicorn_config.rb -p 8080
-ExecStop=/usr/bin/kill -QUIT $MAINPID
+ExecStop=/bin/kill -QUIT $MAINPID
 ExecReload=/bin/kill -USR2 $MAINPID
 
 [Install]


### PR DESCRIPTION
I got following error when I stop agent.ruby in bench server.

```
# systemctl stop agent.ruby
# systemctl status agent.ruby
● agent.ruby.service - bench-ruby
   Loaded: loaded (/etc/systemd/system/agent.ruby.service; disabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Sat 2015-10-03 08:17:40 JST; 17min ago
 Main PID: 19947 (code=killed, signal=TERM)

Oct 03 08:17:40 isucon5-qualifier-bench systemd[1]: Started bench-ruby.
Oct 03 08:17:40 isucon5-qualifier-bench systemd[1]: Starting bench-ruby...
Oct 03 08:17:40 isucon5-qualifier-bench systemd[1]: Stopping bench-ruby...
Oct 03 08:17:40 isucon5-qualifier-bench systemd[19951]: Failed at step EXEC spawning /usr/bin/kill: No such file or directory
Oct 03 08:17:40 isucon5-qualifier-bench systemd[1]: agent.ruby.service: control process exited, code=exited status=203
Oct 03 08:17:40 isucon5-qualifier-bench systemd[1]: Stopped bench-ruby.
Oct 03 08:17:40 isucon5-qualifier-bench systemd[1]: Unit agent.ruby.service entered failed state.
Oct 03 08:17:40 isucon5-qualifier-bench systemd[1]: agent.ruby.service failed.
```

This PR fixes kill command path.
